### PR TITLE
Como usar la solicitud de permisos

### DIFF
--- a/app/src/main/java/com/buildingdreamcars/tallergestionapp/Activities/EstadoActivity.java
+++ b/app/src/main/java/com/buildingdreamcars/tallergestionapp/Activities/EstadoActivity.java
@@ -3,12 +3,10 @@ package com.buildingdreamcars.tallergestionapp.Activities;
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 
 import android.Manifest;
 import android.app.Activity;
 import android.content.DialogInterface;
-import android.content.Intent;
 import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
@@ -16,7 +14,6 @@ import android.graphics.Paint;
 import android.graphics.Path;
 import android.os.Bundle;
 import android.os.Environment;
-import android.provider.MediaStore;
 import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.View;
@@ -24,14 +21,11 @@ import android.widget.Button;
 import android.widget.Toast;
 
 import com.buildingdreamcars.tallergestionapp.R;
-import com.buildingdreamcars.tallergestionapp.Utiles.display;
 
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
 
 import static com.buildingdreamcars.tallergestionapp.Utiles.display.pathList;
 

--- a/app/src/main/java/com/buildingdreamcars/tallergestionapp/Activities/EstadoActivity.java
+++ b/app/src/main/java/com/buildingdreamcars/tallergestionapp/Activities/EstadoActivity.java
@@ -2,9 +2,14 @@ package com.buildingdreamcars.tallergestionapp.Activities;
 
 import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
+import android.Manifest;
+import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.graphics.Paint;
@@ -25,6 +30,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import static com.buildingdreamcars.tallergestionapp.Utiles.display.pathList;
 
@@ -35,25 +42,25 @@ public class EstadoActivity extends AppCompatActivity {
     public static Paint paint_brush = new Paint();
     private Bitmap mBitmap;
 
+    Button btnsave, btndelete;
 
-    Button btnsave,btndelete;
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        verificarStoragePermisos(this);
         setContentView(R.layout.activity_estado);
         DisplayMetrics medidas = new DisplayMetrics();
         getWindowManager().getDefaultDisplay().getMetrics(medidas);
         int ancho = medidas.widthPixels;
         int alto = medidas.heightPixels;
-        getWindow().setLayout(ancho=1000,alto=1750);
+        getWindow().setLayout(ancho = 1000, alto = 1750);
 
         paint_brush.setColor(Color.BLACK);
-        mBitmap=Bitmap.createBitmap(ancho,alto, Bitmap.Config.ARGB_8888);
+        mBitmap = Bitmap.createBitmap(ancho, alto, Bitmap.Config.ARGB_8888);
 
 
-
-        btnsave=findViewById(R.id.btn_guardar_estado);
-        btndelete=findViewById(R.id.btn_borrar_estado);
+        btnsave = findViewById(R.id.btn_guardar_estado);
+        btndelete = findViewById(R.id.btn_borrar_estado);
         btnsave.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
@@ -67,7 +74,8 @@ public class EstadoActivity extends AppCompatActivity {
             }
         });
     }
-    public void asksave(){
+
+    public void asksave() {
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle("Atención");
         builder.setMessage("¿Deseas guardar el estado actual del vehiculo?");
@@ -89,13 +97,16 @@ public class EstadoActivity extends AppCompatActivity {
         builder.show();
 
     }
-    public void delete(){
+
+    public void delete() {
         pathList.clear();
         mPath.reset();
         Toast.makeText(this, "Borrado", Toast.LENGTH_SHORT).show();
     }
-    public void save(){
-        File sdDirectory = Environment.getStorageDirectory();
+
+    public void save() {
+        File sdDirectory = Environment.getExternalStorageDirectory(); // Environment.getStorageDirectory();
+        // sorry my divice soporting SDK 29
         File image = new File(sdDirectory, "/test.jpg");
 
         try {
@@ -115,6 +126,45 @@ public class EstadoActivity extends AppCompatActivity {
             Log.e("TAG", "Entro en el 2 catch");
 
         }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults) {
+        if (requestCode == 100) {
+            if (grantResults.length > 0
+                    && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+                // do something
+            }
+            return;
         }
+    }
+
+    // Storage Permisos
+    private static final int REQUEST_EXTERNAL_STORAGE = 1;
+    private static String[] PERMISSIONS_STORAGE = {
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+    };
+
+    /**
+     * Comprueba si la aplicación tiene permiso para escribir en el device storage
+     *
+     * Si la aplicación no tiene permiso, se le pedirá al usuario que otorgue permisos
+     *
+     * @param activity
+     */
+    public static void verificarStoragePermisos(Activity activity) {
+        // Comprueba si tenemos permiso de escritura
+        int iPermisos = ActivityCompat.checkSelfPermission(activity, Manifest.permission.WRITE_EXTERNAL_STORAGE);
+
+        if (iPermisos != PackageManager.PERMISSION_GRANTED) {
+            // No tenemos permiso hay que solicitárselas al usuario
+            ActivityCompat.requestPermissions(
+                    activity,
+                    PERMISSIONS_STORAGE,
+                    REQUEST_EXTERNAL_STORAGE
+            );
+        }
+    }
 
 }


### PR DESCRIPTION
Ejemplo practico de como usar la solicitud de permisos, debes mover el código a un utilitario (ya que fácilmente es reutilizable) y para que no tengas que solicitarla en cada actividad que debe hacer algo puedes extenderla en la actividad del arranque de la aplicación que pregunte por si tienes los permisos adecuados.

en SDK anteriores no era necesario preguntarle explícitamente la usuario, pero por temas de seguridad y experiencia de usuario el SDK debe preguntar al usuario para darle los permisos adecuados, por más de que estén en el manifest.xml